### PR TITLE
Fix. Do not check input and output in test

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -3,8 +3,6 @@ name: Release Gem
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   push:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    witsec (0.1.1)
+    witsec (0.1.2)
       rails (~> 8.0)
 
 GEM

--- a/lib/witsec/anonymizer.rb
+++ b/lib/witsec/anonymizer.rb
@@ -77,6 +77,8 @@ module Witsec
     private
 
     def check_input_and_output_are_different
+      return if Rails.env.test?
+
       if input_connection_pool.lease_connection.current_database == output_connection_pool.lease_connection.current_database
         raise Witsec::InputAndOutputDatabasesAreTheSame, "You've probably forgotten to setup the output database. It must be named anonymized."
       end

--- a/lib/witsec/version.rb
+++ b/lib/witsec/version.rb
@@ -1,3 +1,3 @@
 module Witsec
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
There is no reason to perform this check in test and it makes setting up CI checks more difficult.