### PR TITLE
Experiment. Sequel.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     witsec (0.1.2)
       rails (~> 8.0)
+      sequel (~> 5.94.0)
 
 GEM
   remote: https://rubygems.org/
@@ -231,6 +232,8 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sequel (5.94.0)
+      bigdecimal
     sqlite3 (2.6.0-aarch64-linux-gnu)
     sqlite3 (2.6.0-aarch64-linux-musl)
     sqlite3 (2.6.0-arm-linux-gnu)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     witsec (0.1.2)
+      dry-configurable (~> 1.3.0)
       rails (~> 8.0)
       sequel (~> 5.94.0)
 
@@ -89,6 +90,13 @@ GEM
     crass (1.0.6)
     date (3.4.1)
     drb (2.2.1)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     erubi (1.13.1)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)

--- a/lib/witsec.rb
+++ b/lib/witsec.rb
@@ -3,8 +3,27 @@ require "witsec/railtie"
 require "witsec/alias"
 require "witsec/anonymizer"
 require "witsec/schema"
+require "dry-configurable"
 
 module Witsec
+  extend Dry::Configurable
+
+  setting :input do
+    setting :adapter, default: :postgres, constructor: proc { |value| (value.to_sym == :postgresql) ? :postgres : value }
+    setting :host
+    setting :database, default: :primary
+    setting :user
+    setting :password
+  end
+
+  setting :output do
+    setting :adapter, default: :postgres, constructor: proc { |value| (value.to_sym == :postgresql) ? :postgres : value }
+    setting :host
+    setting :database, default: :anonymized
+    setting :user
+    setting :password
+  end
+
   class InputAndOutputDatabasesAreTheSame < StandardError
   end
 end

--- a/lib/witsec/alias.rb
+++ b/lib/witsec/alias.rb
@@ -1,17 +1,15 @@
 module Witsec
   class Alias
     def initialize(table_name, columns:, schema:)
-      @table_name = table_name
+      @table_name = table_name.to_s
       @columns = columns
       @schema = schema
     end
 
     def anonymize(rows)
       rows.map do |row|
-        table = schema.anonymized_tables.find { _1.name == table_name }
-
         columns.each_with_index.map do |column, index|
-          anonymized_column, mask = table.columns.find { |name, _mask| name == column }
+          anonymized_column, mask = table.columns.find { |name, _mask| name == column.to_s }
 
           if anonymized_column.present?
             mask.respond_to?(:call) ? mask.call : mask
@@ -25,5 +23,9 @@ module Witsec
     private
 
     attr_reader :table_name, :columns, :schema
+
+    def table
+      @table ||= schema.anonymized_tables.find { _1.name == table_name }
+    end
   end
 end

--- a/lib/witsec/anonymizer.rb
+++ b/lib/witsec/anonymizer.rb
@@ -58,6 +58,8 @@ module Witsec
       puts "Anonymized all in #{time.real} seconds"
     end
 
+    private
+
     def clear_output_database
       puts "Clearing output database"
 
@@ -73,8 +75,6 @@ module Witsec
         output_connection_pool.release_connection
       end
     end
-
-    private
 
     def check_input_and_output_are_different
       return if Rails.env.test?

--- a/lib/witsec/anonymizer.rb
+++ b/lib/witsec/anonymizer.rb
@@ -2,8 +2,8 @@ module Witsec
   class Anonymizer
     BATCH_SIZE = 1000
 
-    def initialize
-      @schema = instance_eval(File.read("config/witsec/schema.rb"))
+    def initialize(schema_path = "config/witsec/schema.rb")
+      @schema = instance_eval(File.read(schema_path))
 
       check_input_and_output_are_different
     end

--- a/lib/witsec/anonymizer.rb
+++ b/lib/witsec/anonymizer.rb
@@ -12,47 +12,29 @@ module Witsec
 
     attr_reader :schema
 
-    # TODO: Make silence configurable
     def anonymize
       time = Benchmark.measure do
-        silence do
-          clear_output_database
+        clear_output_database
 
-          tables.each do |table_name|
-            if schema.anonymizes?(table_name)
-              # A performance improvement could probably be found here, if we just passed along included tables (as in tables, where no rows are anonymized) without querying etc.
+        input_database.tables.each do |table_name|
+          next unless schema.anonymizes?(table_name)
 
-              input_connection = input_connection_pool.lease_connection
-              record_rows = input_connection.execute("SELECT * FROM #{table_name}").to_a
-              columns = record_rows&.first&.keys
-              rows = record_rows.map(&:values)
-              puts "Anonymizing #{table_name} (#{rows.size} rows)"
-              input_connection_pool.release_connection
+          # A performance improvement could probably be found here, if we just passed along included tables (as in tables, where no rows are anonymized) without querying etc.
+          record_rows = input_database[table_name].all
+          columns = record_rows&.first&.keys
+          rows = record_rows.map(&:values)
+          puts "Anonymizing #{table_name} (#{rows.size} rows)"
 
-              anonymized_rows = Witsec::Alias.new(table_name, columns:, schema:).anonymize(rows)
-              output_connection = output_connection_pool.lease_connection
-              # If referential integrity is not disabled, you have to create all rows in the correct order
-              output_connection.disable_referential_integrity do
-                # Use insert for performance
-                row_batches = anonymized_rows.in_groups_of(BATCH_SIZE, false)
-                total = 0
-                row_batches.each_with_index do |batch, index|
-                  print "Anonymizing up to row #{total + batch.size} of #{rows.size}\r"
-                  total += batch.size
-                  values = batch.map do |row|
-                    "(#{row.map { |value| quote(value) }.join(", ")})"
-                  end.join(", ")
+          anonymized_rows = Witsec::Alias.new(table_name, columns:, schema:).anonymize(rows)
 
-                  output_connection.execute(
-                    "INSERT INTO #{table_name} (#{columns.join(", ")}) VALUES #{values}"
-                  )
-                end
-              end
+          row_batches = anonymized_rows.in_groups_of(BATCH_SIZE, false)
+          total = 0
+          row_batches.each_with_index do |batch, index|
+            print "Anonymizing up to row #{total + batch.size} of #{rows.size}\r"
+            total += batch.size
 
-              output_connection_pool.release_connection
-            else
-              puts "Skipping #{table_name}"
-              next
+            disable_output_referential_integrity do
+              output_database[table_name].import(columns, batch)
             end
           end
         end
@@ -73,45 +55,47 @@ module Witsec
     def check_input_and_output_are_different
       return if Rails.env.test?
 
-      if input_connection_pool.lease_connection.current_database == output_connection_pool.lease_connection.current_database
+      if input_database == output_database
         raise Witsec::InputAndOutputDatabasesAreTheSame, "You've probably forgotten to setup the output database. It must be named anonymized."
       end
-    end
-
-    def tables
-      ActiveRecord::Base.connection.tables
-    end
-
-    def silence(&block)
-      ActiveRecord::Base.logger.silence(&block)
-    end
-
-    def quote(value)
-      ActiveRecord::Base.connection.quote(value)
     end
 
     def input_database_configuration
       Rails.configuration.database_configuration[Rails.env]["primary"]
     end
 
-    def input_connection_pool
-      ActiveRecord::Base.establish_connection(input_database_configuration)
-    end
-
     def output_database_configuration
       Rails.configuration.database_configuration[Rails.env]["anonymized"]
-    end
-
-    def output_connection_pool
-      ActiveRecord::Base.establish_connection(output_database_configuration)
     end
 
     def output_database
       @output_database ||= begin
         config = output_database_configuration.slice("host", "database", "password")
           .merge("adapter" => "postgres", "user" => output_database_configuration["username"])
-        
+
         Sequel.connect(**config)
+      end
+    end
+
+    def input_database
+      @input_database ||= begin
+        config = input_database_configuration.slice("host", "database", "password")
+          .merge("adapter" => "postgres", "user" => output_database_configuration["username"])
+
+        Sequel.connect(**config)
+      end
+    end
+
+    def disable_output_referential_integrity(&block)
+      case output_database.adapter_scheme
+      when :postgres
+        output_database.run(output_database.tables.collect { |name| "ALTER TABLE #{name} DISABLE TRIGGER ALL" }.join(";"))
+        
+        yield
+
+        output_database.run(output_database.tables.collect { |name| "ALTER TABLE #{name} ENABLE TRIGGER ALL" }.join(";"))
+      else
+        raise "Cannot disable referential integrity for #{output_database.adapter_scheme}"
       end
     end
   end

--- a/lib/witsec/schema.rb
+++ b/lib/witsec/schema.rb
@@ -35,7 +35,7 @@ module Witsec
     end
 
     def anonymizes?(table_name)
-      anonymized_table_names.include?(table_name)
+      anonymized_table_names.include?(table_name.to_s)
     end
 
     def table_names

--- a/witsec.gemspec
+++ b/witsec.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", "~> 8.0"
+  spec.add_dependency "sequel", "~> 5.94.0"
   spec.add_development_dependency "minitest-spec-rails"
   spec.add_development_dependency "faker"
   spec.add_development_dependency "standard", "~> 1.44"

--- a/witsec.gemspec
+++ b/witsec.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", "~> 8.0"
   spec.add_dependency "sequel", "~> 5.94.0"
+  spec.add_dependency "dry-configurable", "~> 1.3.0"
   spec.add_development_dependency "minitest-spec-rails"
   spec.add_development_dependency "faker"
   spec.add_development_dependency "standard", "~> 1.44"


### PR DESCRIPTION
Replaces ActiveRecord with Sequel. This paves the way for making the gem framework agnostic and reduces external dependencies. The Rails integration can be moved into an adapter gem.